### PR TITLE
Review and update Helix CLI commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ OPEN_ROUTER_KEY=<your_open_router_api_key>
 ### HelixDB
 You will need to have a HelixDB instance running. Go to the root of this repository and run the following command to deploy the HelixDB instance:
 ```bash
-helix deploy
+helix push dev
 ```
 
 For more information on how to install and use HelixDB, please refer to the [HelixDB documentation](https://docs.helix-db.com/).


### PR DESCRIPTION
Update 'helix deploy' to 'helix push dev' to match CLI v2 syntax. The correct command for deploying to a development environment is 'helix push dev' according to the official HelixDB documentation.